### PR TITLE
Approvals page improvements

### DIFF
--- a/frontend/src/approvals/approvals.html
+++ b/frontend/src/approvals/approvals.html
@@ -1,53 +1,42 @@
 <template>
-<div class="row">
-            <div class="col-md-12">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4>Pending for approval requests, only for approvers </h4>
-                    </div>
+    <require from="./requests"></require>
 
-                    <div class="panel-body">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h4>Your approvals:</h4>
+                </div>
 
-                        <spinner if.bind="!allPendingApprovals.length"></spinner>
+                <div class="panel-body">
+                    <ul  class="nav nav-pills">
+                        <li class="active">
+                            <a  href="#pending" data-toggle="tab">Pending</a>
+                        </li>
+                        <li>
+                            <a href="#approved" data-toggle="tab">Approved</a>
+                        </li>
+                        <li>
+                            <a href="#rejected" data-toggle="tab">Rejected</a>
+                        </li>
+                    </ul>
+                    <hr></hr>
 
-                        <ul class="list-group">
-                            <li repeat.for="request of allPendingApprovals"
-                                class="list-group-item ${request.status | computeBadge}">
-                                 <div
-                                    if.bind="request.status == 'pending'"
-                                    class="btn-group">
+                    <div class="tab-content clearfix">
+                        <div class="tab-pane active" id="pending">
+                            <requests requests.bind="allPendingRequests" loading.bind="pendingLoading"></requests>
+                        </div>
 
-                                    <button
-                                        type="button"
-                                        class="btn btn-default dropdown-toggle"
-                                        data-toggle="dropdown"
-                                        aria-haspopup="true"
-                                        aria-expanded="false">
-                                        Action<span class="caret"></span>
-                                    </button>
+                        <div class="tab-pane" id="approved">
+                            <requests requests.bind="allApprovedRequests" loading.bind="approvedLoading"></requests>
+                        </div>
 
-                                    <ul class="dropdown-menu">
-                                        <li><a click.delegate="approveRequest(request)">Approve</a></li>
-                                        <li><a click.delegate="rejectRequest(request)">Reject</a></li>
-                                    </ul>
-                                </div>
-
-                                ${request.user.fullName} |
-                                <span>
-                                    ${request.workDays} ${request.workDays > 1 ? 'Days' : 'Day'} |
-                                </span>
-                                ${request.start | dateFormat}
-                                <span show.bind="showExtra(request)">
-                                    - ${request.end | dateFormat}
-                                </span>
-                                    | ${request.leaveType | humanizeLeave}
-                                <span if.bind="request.status != 'pending'" class="badge badge-pill">
-                                    ${request.status}
-                                </span>
-                            </li>
-                        </ul>
+                        <div class="tab-pane" id="rejected">
+                            <requests requests.bind="allRejectedRequests" loading.bind="rejectedLoading"></requests>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 </template>

--- a/frontend/src/approvals/approvals.js
+++ b/frontend/src/approvals/approvals.js
@@ -13,13 +13,18 @@ export class Approvals {
         this._leave = _leave;
         this._user = _user;
     }
+
     activate() {
-        this.pendingRequests();
-        this.approvedRequests();
-        this.rejectedRequests();
+        this.fetchRequests();
     }
 
-    async pendingRequests() {
+    fetchRequests() {
+        this.fetchPendingRequests();
+        this.fetchApprovedRequests();
+        this.fetchRejectedRequests();
+    }
+
+    async fetchPendingRequests() {
         let pendingsRequests = await this._leave.getPendingRequests();
 
         pendingsRequests = await this.agregateUserData(pendingsRequests);
@@ -29,7 +34,7 @@ export class Approvals {
     }
 
 
-    async approvedRequests() {
+    async fetchApprovedRequests() {
         let approvedRequests = await this._leave.getApprovedRequests();
 
         approvedRequests = await this.agregateUserData(approvedRequests);
@@ -38,7 +43,7 @@ export class Approvals {
         this.approvedLoading = false;
     }
 
-    async rejectedRequests() {
+    async fetchRejectedRequests() {
         let rejectedRequests = await this._leave.getRejectedRequests();
 
         rejectedRequests = await this.agregateUserData(rejectedRequests);

--- a/frontend/src/approvals/approvals.js
+++ b/frontend/src/approvals/approvals.js
@@ -1,45 +1,58 @@
 import { inject } from 'aurelia-framework';
-import { HttpClient } from 'aurelia-http-client';
 import { LeaveService } from '~/services/leave-service';
 import { UserService } from '~/services/user-service';
-import { AuthService } from '~/services/auth-service';
 import { REQUEST_STATUS } from '~/util/constants';
 
 @inject(LeaveService, UserService)
 export class Approvals {
+    pendingLoading = true;
+    approvedLoading = true;
+    rejectedLoading = true;
+
     constructor(_leave, _user) {
         this._leave = _leave;
         this._user = _user;
     }
     activate() {
-        this.pendingApprovals();
+        this.pendingRequests();
+        this.approvedRequests();
+        this.rejectedRequests();
     }
 
-    async pendingApprovals() {
-        const pendings = await this._leave.getPendingApprovals();
-        const complete = await Promise.all(pendings.map(async item => {
+    async pendingRequests() {
+        let pendingsRequests = await this._leave.getPendingRequests();
+
+        pendingsRequests = await this.agregateUserData(pendingsRequests);
+
+        this.allPendingRequests = pendingsRequests;
+        this.pendingLoading = false;
+    }
+
+
+    async approvedRequests() {
+        let approvedRequests = await this._leave.getApprovedRequests();
+
+        approvedRequests = await this.agregateUserData(approvedRequests);
+
+        this.allApprovedRequests = approvedRequests;
+        this.approvedLoading = false;
+    }
+
+    async rejectedRequests() {
+        let rejectedRequests = await this._leave.getRejectedRequests();
+
+        rejectedRequests = await this.agregateUserData(rejectedRequests);
+
+        this.allRejectedRequests = rejectedRequests;
+        this.rejectedLoading = false;
+    }
+
+    agregateUserData(pendings) {
+        return Promise.all(pendings.map(async item => {
             const user = await this._user.getUser(item.userId);
 
             item.user = user;
             return item;
         }));
-
-        this.allPendingApprovals = complete;
-    }
-
-    async approveRequest(request) {
-        const response = await this._leave.updateLeaveRequestStatus(request, REQUEST_STATUS.APPROVED);
-        console.log('approve', response)
-        return response;
-    }
-
-    async rejectRequest(request) {
-        const response = await this._leave.updateLeaveRequestStatus(request, REQUEST_STATUS.REJECTED);
-        console.log('reject', response)
-        return response;
-    }
-
-    showExtra(extra) {
-        return extra.workDays > 1 ? true : false;
     }
 }

--- a/frontend/src/approvals/requests.html
+++ b/frontend/src/approvals/requests.html
@@ -1,0 +1,47 @@
+<template bindable="requests,loading">
+
+    <ul if.bind="loading || !requests.length" class="list-group">
+        <li class="list-group-item spinner">
+            <spinner show.bind="loading"></spinner>
+            <span show.bind="!loading">You have no requests here !</span>
+        </li>
+    </ul>
+
+    <ul class="list-group">
+        <li repeat.for="request of requests"
+            class="list-group-item ${request.status | computeBadge}">
+            <div
+                if.bind="request.status == 'pending'"
+                class="btn-group">
+
+                <button
+                    type="button"
+                    class="btn btn-default dropdown-toggle"
+                    data-toggle="dropdown"
+                    aria-haspopup="true"
+                    aria-expanded="false">
+                Action<span class="caret"></span>
+                </button>
+
+                <ul class="dropdown-menu">
+                    <li><a click.delegate="approveRequest(request)">Approve</a></li>
+                    <li><a click.delegate="rejectRequest(request)">Reject</a></li>
+                </ul>
+            </div>
+
+            ${request.user.fullName} |
+            <span>
+                ${request.workDays} ${request.workDays > 1 ? 'Days' : 'Day'} |
+            </span>
+
+            ${request.start | dateFormat}
+            <span show.bind="showExtra(request)">
+                - ${request.end | dateFormat}
+            </span>
+            | ${request.leaveType | humanizeLeave}
+            <span if.bind="request.status != 'pending'" class="badge badge-pill">
+                ${request.status}
+            </span>
+        </li>
+    </ul>
+</template>

--- a/frontend/src/approvals/requests.html
+++ b/frontend/src/approvals/requests.html
@@ -1,7 +1,7 @@
 <template bindable="requests,loading">
 
     <ul if.bind="loading || !requests.length" class="list-group">
-        <li class="list-group-item spinner">
+        <li class="list-group-item spinner-wrapper">
             <spinner show.bind="loading"></spinner>
             <span show.bind="!loading">You have no requests here !</span>
         </li>

--- a/frontend/src/approvals/requests.js
+++ b/frontend/src/approvals/requests.js
@@ -1,0 +1,25 @@
+import { bindable, inject } from 'aurelia-framework';
+import { LeaveService } from '~/services/leave-service';
+import { REQUEST_STATUS } from '~/util/constants';
+
+@inject(LeaveService)
+export class Requests {
+  @bindable requests = [];
+  @bindable loading = false;
+
+  constructor(_leave){
+    this._leave = _leave;
+  }
+
+    approveRequest(request) {
+        return this._leave.updateLeaveRequestStatus(request, REQUEST_STATUS.APPROVED);
+    }
+
+    rejectRequest(request) {
+        return this._leave.updateLeaveRequestStatus(request, REQUEST_STATUS.REJECTED);
+    }
+
+    showExtra(extra) {
+        return extra.workDays > 1 ? true : false;
+    }
+}

--- a/frontend/src/approvals/requests.js
+++ b/frontend/src/approvals/requests.js
@@ -4,12 +4,12 @@ import { REQUEST_STATUS } from '~/util/constants';
 
 @inject(LeaveService)
 export class Requests {
-  @bindable requests = [];
-  @bindable loading = false;
+    @bindable requests = [];
+    @bindable loading = false;
 
-  constructor(_leave){
-    this._leave = _leave;
-  }
+    constructor(_leave){
+        this._leave = _leave;
+    }
 
     approveRequest(request) {
         return this._leave.updateLeaveRequestStatus(request, REQUEST_STATUS.APPROVED);

--- a/frontend/src/services/leave-service.js
+++ b/frontend/src/services/leave-service.js
@@ -72,21 +72,16 @@ export class LeaveService {
         return this.http.post('leaves', leave);
     }
 
-    getApprovedLeaves() {
-        return new Promise((resolve, reject) => {
-            setTimeout(() => {
-                resolve(this.approvedLeaves);
-            }, 500)
-        })
+    getPendingRequests() {
+        return this.fetch('leaves/pending');
     }
 
-    getPendingApprovals() {
-        //todo send filtering params to leaves
-        return this.http.get('leaves')
-            .then(res => {
-                return JSON.parse(res.response)
-                    .filter(item => item.status === REQUEST_STATUS.PENDING)
-            });
+    getApprovedRequests() {
+        return this.fetch('leaves/approved');
+    }
+
+    getRejectedRequests() {
+        return this.fetch('leaves/rejected');
     }
 
     updateLeaveRequestStatus(request, status) {
@@ -95,5 +90,10 @@ export class LeaveService {
             .then(res => {
                 console.log('the response', JSON.parse(res.response));
             });
+    }
+
+    fetch(endpoint) {
+        return this.http.get(endpoint)
+            .then(res => JSON.parse(res.response));
     }
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -10,6 +10,6 @@ ai-dialog-overlay.active {
     cursor:pointer
 }
 
-.spinner {
+.spinner-wrapper {
     border: none;
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -9,3 +9,7 @@ ai-dialog-overlay.active {
 .admin-card {
     cursor:pointer
 }
+
+.spinner {
+    border: none;
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "scripts": {
     "install": "cd ./frontend && yarn install && cd ../backend && yarn install",
-    "build": "cd ./frontend && au build --env dev && cd ../backend && gulp",
+    "build": "cd ./frontend && au build --env prod && cd ../backend && gulp",
     "lint": "cd ./backend && yarn lint"
   },
   "dependencies": {


### PR DESCRIPTION
Approvers will start to see only the requests that are created by users assigned to the project for which he(the approver) is assigned

the approver will be able to see Pending/Accepted/Rejected requests

similar to these:
![screen shot 2017-11-01 at 13 02 29](https://user-images.githubusercontent.com/8307102/32272020-023e9f22-bf05-11e7-8586-c59a20cca649.png)
![screen shot 2017-11-01 at 13 02 33](https://user-images.githubusercontent.com/8307102/32272021-02673022-bf05-11e7-9b30-1e2fff37fb67.png)
![screen shot 2017-11-01 at 13 02 39](https://user-images.githubusercontent.com/8307102/32272022-02866cda-bf05-11e7-85fc-2bb7a1fbe098.png)
