### PR TITLE
DSL support for advance query based on model schema

### DIFF
--- a/backend/server/controllers/project.controller.js
+++ b/backend/server/controllers/project.controller.js
@@ -1,6 +1,7 @@
 import Project from '../models/project.model';
 import User from '../models/user.model';
 import APIError from '../helpers/APIError';
+import queryHelper from '../helpers/query-support';
 
 function load(req, res, next, id) {
     Project.get(id)
@@ -87,4 +88,10 @@ async function getApprovers(req, res, next) {
         .catch(e => next(e));
 }
 
-export default { load, get, create, update, list, remove, getUsers, getApprovers };
+function queryInfo(req, res) {
+    const data = queryHelper.getQueryData(Project.schema);
+
+    res.json(data);
+}
+
+export default { load, get, create, update, list, remove, getUsers, getApprovers, queryInfo };

--- a/backend/server/controllers/user.controller.js
+++ b/backend/server/controllers/user.controller.js
@@ -2,6 +2,7 @@ import bcrypt from 'bcrypt';
 import User from '../models/user.model';
 import worker from '../../worker/worker';
 import _ from 'lodash';
+import queryHelper from '../helpers/query-support';
 
 function load(req, res, next, id) {
     User.get(id)
@@ -131,4 +132,12 @@ function remove(req, res, next) {
         .catch(e => next(e));
 }
 
-export default { load, get, create, update, list, remove };
+function queryInfo(req, res) {
+    const sensitiveFields = ['password'];
+
+    const data = queryHelper.getQueryData(User.schema, sensitiveFields);
+
+    res.json(data);
+}
+
+export default { load, get, create, update, list, remove, queryInfo };

--- a/backend/server/helpers/query-support.js
+++ b/backend/server/helpers/query-support.js
@@ -1,0 +1,51 @@
+function getQueryData(schema, sensitiveFields = []) {
+    const { obj, paths } = schema;
+    const fields = Object.keys(obj).filter(e => sensitiveFields.indexOf(e) === -1);
+
+    const data = {};
+
+    fields.forEach(field => {
+        data[field] = fetchFieldQueryData(paths[field]);
+    });
+
+    return data;
+}
+
+function fetchFieldQueryData(path) {
+    const type = path.instance;
+
+    switch(path.instance) {
+    case 'String':
+        return { type, operations: getStringQueryData() };
+    case 'Number':
+        return { type, operations: getNumberQueryData() };
+    case 'Date':
+        return { type, operations: getDateQueryData() };
+    case 'Array':
+        return { type, item_type: path.caster.instance, operations: fetchArrayQueryData() };
+    }
+}
+
+function fetchArrayQueryData() {
+    return ['in', 'not_in'];
+}
+
+function getStringQueryData() {
+    return [
+        'contains', 'not_contains', 'equals', 'not_equals'
+    ];
+}
+
+function getNumberQueryData() {
+    return [
+        'greater_than', 'less_than', 'equals', 'not_equals'
+    ];
+}
+
+function getDateQueryData() {
+    return [
+        'before', 'after', 'equals', 'not_equals'
+    ];
+}
+
+export default { getQueryData };


### PR DESCRIPTION
The goal is to provide a way to let F/E know on the operations that can be performed over the models, when doing advanced filtering

for the moment B/E will serve something as below, to instruct F/E on how to manipulate data for querying 


`GET api/projects/queryInfo` would return:
```json
{
    "name": {
        "type": "String",
        "operations": [
            "contains",
            "not_contains",
            "equals",
            "not_equals"
        ]
    },
    "approvers": {
        "type": "Array",
        "item_type": "String",
        "operations": [
            "in",
            "not_in"
        ]
    },
    "description": {
        "type": "String",
        "operations": [
            "contains",
            "not_contains",
            "equals",
            "not_equals"
        ]
    },
    "roles": {
        "type": "Array",
        "item_type": "String",
        "operations": [
            "in",
            "not_in"
        ]
    },
    "createdAt": {
        "type": "Date",
        "operations": [
            "before",
            "after",
            "equals",
            "not_equals"
        ]
    }
}
```